### PR TITLE
Clear form on edit

### DIFF
--- a/public/pantry-volunteers/vol-inventory/index.html
+++ b/public/pantry-volunteers/vol-inventory/index.html
@@ -471,7 +471,6 @@
 <!-- Toast -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 <!-- Page related scripts -->
-<!-- <script src="../../scripts/admin.js"></script> -->
 <script src="../../scripts/vol-inventory.js"></script>
 <script src="../../scripts/restock.js"></script>
 

--- a/public/pantry-volunteers/vol-inventory/index.html
+++ b/public/pantry-volunteers/vol-inventory/index.html
@@ -471,7 +471,7 @@
 <!-- Toast -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 <!-- Page related scripts -->
-<script src="../../scripts/admin.js"></script>
+<!-- <script src="../../scripts/admin.js"></script> -->
 <script src="../../scripts/vol-inventory.js"></script>
 <script src="../../scripts/restock.js"></script>
 

--- a/public/scripts/restock.js
+++ b/public/scripts/restock.js
@@ -4,7 +4,7 @@ function getCategories() {
   return ['grains', 'canned', 'protein', 'frozen', 'snacks', 'sauces', 'spices', 'beverages'];
 }
 // used by the edit item modal
-function updateItem() {
+function updateExistingItem() {
     var itemName = document.getElementById('editItemName').value;
     var barcode = document.getElementById('editBarcode').value;
     var count = document.getElementById('editCount').value;
@@ -118,7 +118,7 @@ function loadItemIntoEditForm(barcode) {
 }
 
 // Saves a new item in the inventory database. Used by the add item modal
-function saveItem() {
+function saveNewItem() {
 
   // var itemID = generateItemID();
   var itemName = document.getElementById('itemName').value;
@@ -182,13 +182,13 @@ function saveItem() {
 // Triggered when the add new item form is submitted.
 function onAddItemFormSubmit(e) {
   e.preventDefault();
-  saveItem();
+  saveNewItem();
 }
 
 // Triggered when the edit item form is submitted.
 function onEditItemFormSubmit(e) {
   e.preventDefault();
-  updateItem();
+  updateExistingItem();
 }
 
 // Triggered when the add new item form is submitted.


### PR DESCRIPTION
- general cleanup removing some unused code pertaining to our deprecated use of "ItemID"
-  fixes the bug where submitting an item edit doesn't clear the form and shows incorrect toast (#122)
