### PR TITLE
adds display name for mobile client on category add

### DIFF
--- a/public/scripts/admin.js
+++ b/public/scripts/admin.js
@@ -256,10 +256,8 @@ function addNewCategory(e) {
     }
     addCategory(newCategory);
     let toWrite = {};
-    currentCategories.forEach((category) => {
-        toWrite[category] = category;
-    })
-    firebase.database().ref('/category')
+    toWrite["displayName"] = newCategory; 
+    firebase.database().ref('/category/' + newCategory)
         .update(toWrite)
         .then(() => {
             document.getElementById("category-input").value = ''


### PR DESCRIPTION
On category submit, the web app will write a category to the `category` table as well as a child of the category called `categoryDisplayName` so that the mobile app knows what to display as the category name. 

In the future we will probably want a way to edit existing info from categories in the webapp (displayName, icon, etc).